### PR TITLE
Nth order chains

### DIFF
--- a/src/bin/markgen.rs
+++ b/src/bin/markgen.rs
@@ -24,7 +24,7 @@ fn main() {
 /// `markov_gen(vec!["test".to_owned(), "-n".to_owned(), "0".to_owned()])`
 /// `markov_gen(vec!["test".to_owned(), "-n".to_owned(), "test".to_owned()])`
 fn markov_gen(args: Vec<String>) -> Vec<String> {
-    let mut chain = Chain::for_strings();
+    let mut chain = Chain::for_strings().order(2);
     let mut expecting_num = false;
     let mut count = 1usize;
     for arg in args.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl<T> Chain<T> where T: Chainable {
 
     /// Choose a specific Markov chain order. The order is the number of previous tokens to use
     /// as the index into the map.
-    pub fn order(mut self, order: usize) -> Chain<T> {
+    pub fn order(&mut self, order: usize) -> &mut Chain<T> {
         assert!(order > 0);
         self.order = order;
         self.map.insert(vec!(self.start.clone(); self.order), HashMap::new());
@@ -356,7 +356,8 @@ mod test {
 
     #[test]
     fn generate_for_higher_order() {
-        let mut chain = Chain::new(0u8, 100).order(2);
+        let mut chain = Chain::new(0u8, 100);
+        chain.order(2);
         chain.feed(vec![3, 5, 10]).feed(vec![2, 3, 5, 12]);
         let v = chain.generate().into_iter().map(|v| *v).collect();
         assert!([vec![3, 5, 10], vec![3, 5, 12], vec![2, 3, 5, 10], vec![2, 3, 5, 12]].contains(&v));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl<T> Chain<T> where T: Chainable {
 
     /// Choose a specific Markov chain order. The order is the number of previous tokens to use
     /// as the index into the map.
-    pub fn order(&mut self, order: usize) -> &mut Chain<T> {
+    pub fn order(mut self, order: usize) -> Chain<T> {
         assert!(order > 0);
         self.order = order;
         self.map.insert(vec!(self.start.clone(); self.order), HashMap::new());
@@ -352,6 +352,14 @@ mod test {
         chain.feed(vec![3, 5, 10]).feed(vec![5, 12]);
         let v = chain.generate().into_iter().map(|v| *v).collect();
         assert!([vec![3, 5, 10], vec![3, 5, 12], vec![5, 10], vec![5, 12]].contains(&v));
+    }
+
+    #[test]
+    fn generate_for_higher_order() {
+        let mut chain = Chain::new(0u8, 100).order(2);
+        chain.feed(vec![3, 5, 10]).feed(vec![2, 3, 5, 12]);
+        let v = chain.generate().into_iter().map(|v| *v).collect();
+        assert!([vec![3, 5, 10], vec![3, 5, 12], vec![2, 3, 5, 10], vec![2, 3, 5, 12]].contains(&v));
     }
 
     #[test]


### PR DESCRIPTION
I modified the library to allow specifying arbitrary order Markov chains (previously it was restricted to 1st order). 2nd and 3rd order are handy for making text generation more natural looking.

My current arrangement doesn't really work for `generate_from_token()` at anything other than first order chains, but I'm not really sure what the best solution is for that. My first thought is to insert keys into the map for every order level and then if we generate from a single token, we grow the key length until we reach the chain order. This would probably slow down feeding the chain quite a bit though.

I also managed to break saving and loading of the chain. I'm pretty new to rust and serialization, so I'm not really sure where to start with fixing that.