### PR TITLE
Uses the `split_whitespace` iterator.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ impl Chain<String> {
         let reader = BufReader::new(File::open(path).unwrap());
         for line in reader.lines() {
             let line = line.unwrap();
-            let words: Vec<_> = line.split(&[' ', '\t', '\n', '\r'][..])
+            let words: Vec<_> = line.split_whitespace()
                                     .filter(|word| !word.is_empty())
                                     .collect();
             self.feed(words.iter().map(|&s| s.to_owned()).collect());


### PR DESCRIPTION
Rust provides a method to deal with different white spaces beyound the
line separators and space.

http://doc.rust-lang.org/1.6.0/std/primitive.str.html#method.split_whitespace