### PR TITLE
Do the transformation in one pass

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,11 @@ impl Chain<String> {
         let reader = BufReader::new(File::open(path).unwrap());
         for line in reader.lines() {
             let line = line.unwrap();
-            let words: Vec<_> = line.split_whitespace()
-                                    .filter(|word| !word.is_empty())
-                                    .collect();
-            self.feed(words.iter().map(|&s| s.to_owned()).collect());
+            let words = line.split_whitespace()
+                            .filter(|word| !word.is_empty())
+                            .map(|s| s.to_owned())
+                            .collect();
+            self.feed(words);
         }
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ impl Chain<String> {
         let reader = BufReader::new(File::open(path).unwrap());
         for line in reader.lines() {
             let line = line.unwrap();
-            let words: Vec<_> = line.split(&[' ', '\t', '\n', '\r'][..])
+            let words: Vec<_> = line.split_whitespace()
                                     .filter(|word| !word.is_empty())
                                     .collect();
             self.feed(words.iter().map(|&s| s.to_owned()).collect());


### PR DESCRIPTION
Do the line transformation in one pass on file 

Instead of creating two different Vec calling collect twice, this commit do the processing in series before converting into a Vec.

This commit also removes the type suggestion for collect, as it is capable of infering it now by the usage.

This is on top of PR #10 (Uses the `split_whitespace` iterator.)