### PR TITLE
Chain::feed takes AsRef<[T]> instead of Vec<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ use markov::Chain;
 
 fn main() {
     let mut chain = Chain::new();
-    chain.feed(vec![1u8, 2, 3, 5]).feed(vec![3u8, 9, 2]);
+    chain.feed(vec![1u8, 2, 3, 5]).feed([3u8, 9, 2]);
     println!("{:?}", chain.generate());
 }
 ```


### PR DESCRIPTION
Makes `feed` more versatile -- can take `&[T;_]` or `&Vec<T>`. I think it's more common and user-friendly to have this type of usage.

This might count as a breaking change, though, since usage has changed. Sorry for making a PR into `stable`, this probably should be pulled into a different branch. Will edit this PR target to a "less stable" branch if you think so too, and create a new branch.