### PR TITLE
Add seedable generate functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,17 @@ maintenance = { status = "passively-maintained" }
 travis-ci = { repository = "aatxe/markov" }
 
 [features]
-default = ["graph", "markgen", "yaml"]
+default = ["graph", "markgen", "yaml", "seedable"]
 graph = ["petgraph", "itertools"]
 markgen = ["getopts"]
 yaml = ["serde_yaml"]
+seedable = ["linked-hash-map"]
 
 [dependencies]
 getopts = { version = "0.2.21", optional = true }
 itertools = { version = "0.10.1", optional = true }
 petgraph = { version = "0.6.0", optional = true }
-linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
+linked-hash-map = { version = "0.5.6", features = ["serde_impl"], optional = true }
 rand = "0.8.4"
 serde = "1.0.130"
 serde_derive = "1.0.130"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ yaml = ["serde_yaml"]
 getopts = { version = "0.2.21", optional = true }
 itertools = { version = "0.10.1", optional = true }
 petgraph = { version = "0.6.0", optional = true }
+linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 rand = "0.8.4"
 serde = "1.0.130"
 serde_derive = "1.0.130"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = ["graph", "markgen", "yaml", "seedable"]
 graph = ["petgraph", "itertools"]
 markgen = ["getopts"]
 yaml = ["serde_yaml"]
-seedable = ["linked-hash-map"]
+seedable = ["linked-hash-map", "rand_chacha"]
 
 [dependencies]
 getopts = { version = "0.2.21", optional = true }
@@ -32,6 +32,7 @@ itertools = { version = "0.10.1", optional = true }
 petgraph = { version = "0.6.0", optional = true }
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"], optional = true }
 rand = "0.8.4"
+rand_chacha = { version = "0.3.1" , optional = true}
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_yaml = { version = "0.8.20", optional = true }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 [bws]: https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg
 [sm]: http://spacemacs.org
 
-> Forked from [aatxe/markov](https://github.com/aatxe/markov) but adds the possiblity to pass in your own RNG
-
 A generic implementation of a [Markov chain](https://en.wikipedia.org/wiki/Markov_chain) in Rust. It
 supports all types that implement `Eq`, `Hash`, and `Clone`, and has some specific helpers for
 working with `String` as text generation is the most likely use case. You can find up-to-date,

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [bws]: https://cdn.rawgit.com/syl20bnr/spacemacs/442d025779da2f62fc86c2082703697714db6514/assets/spacemacs-badge.svg
 [sm]: http://spacemacs.org
 
+> Forked from [aatxe/markov](https://github.com/aatxe/markov) but adds the possiblity to pass in your own RNG
+
 A generic implementation of a [Markov chain](https://en.wikipedia.org/wiki/Markov_chain) in Rust. It
 supports all types that implement `Eq`, `Hash`, and `Clone`, and has some specific helpers for
 working with `String` as text generation is the most likely use case. You can find up-to-date,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use std::path::Path;
 use itertools::Itertools;
 #[cfg(feature = "graph")]
 use petgraph::graph::Graph;
-use rand::{thread_rng, Rng, SeedableRng};
+use rand::{thread_rng, Rng};
 #[cfg(feature = "yaml")]
 use serde::de::DeserializeOwned;
 #[cfg(feature = "yaml")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,19 @@ extern crate serde_yaml;
 #[cfg(feature = "seedable")]
 extern crate linked_hash_map;
 
+#[cfg(feature = "seedable")]
+extern crate rand_chacha;
+
 use std::borrow::ToOwned;
 
 #[cfg(feature = "seedable")]
 use linked_hash_map::Entry::{Occupied, Vacant};
 #[cfg(feature = "seedable")]
 use linked_hash_map::LinkedHashMap as HashMap;
+
+#[cfg(feature = "seedable")]
+use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
+
 #[cfg(not(feature = "seedable"))]
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 #[cfg(not(feature = "seedable"))]
@@ -57,7 +64,7 @@ use std::path::Path;
 use itertools::Itertools;
 #[cfg(feature = "graph")]
 use petgraph::graph::Graph;
-use rand::{thread_rng, Rng, SeedableRng};
+use rand::{thread_rng, Rng};
 #[cfg(feature = "yaml")]
 use serde::de::DeserializeOwned;
 #[cfg(feature = "yaml")]
@@ -164,7 +171,7 @@ where
     /// state. Takes a seed.
     #[cfg(feature = "seedable")]
     pub fn generate_with_seed(&self, seed: u64) -> Vec<T> {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
         self.generate_base(&mut rng)
     }
 
@@ -208,7 +215,7 @@ where
     /// found. Takes a seed.
     #[cfg(feature = "seedable")]
     pub fn generate_from_token_with_seed(&self, token: T, seed: u64) -> Vec<T> {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut rng = ChaCha12Rng::seed_from_u64(seed);
         self.generate_from_token_base(token, &mut rng)
     }
 
@@ -492,7 +499,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use rand::SeedableRng;
+
+    use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
 
     use super::Chain;
 
@@ -536,7 +544,7 @@ mod test {
 
     #[test]
     fn generate_with_rng() {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(3);
+        let mut rng = ChaCha12Rng::seed_from_u64(3);
         let mut chain = Chain::new();
         chain.feed(vec![3u8, 5, 10]).feed(vec![5, 12]);
         let v = chain.generate_with_rng(&mut rng);
@@ -579,7 +587,7 @@ mod test {
 
     #[test]
     fn generate_from_token_with_rng() {
-        let mut rng = rand::rngs::StdRng::seed_from_u64(3);
+        let mut rng = ChaCha12Rng::seed_from_u64(3);
         let mut chain = Chain::new();
         chain.feed(vec![3u8, 5, 10, 13]).feed(vec![5, 12, 10]);
         let v = chain.generate_from_token_with_rng(5, &mut rng);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use std::path::Path;
 use itertools::Itertools;
 #[cfg(feature = "graph")]
 use petgraph::graph::Graph;
-use rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng, SeedableRng};
 #[cfg(feature = "yaml")]
 use serde::de::DeserializeOwned;
 #[cfg(feature = "yaml")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,6 +492,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use rand::SeedableRng;
+
     use super::Chain;
 
     #[test]
@@ -523,6 +525,27 @@ mod test {
     }
 
     #[test]
+    fn generate_with_seed() {
+        let mut chain = Chain::new();
+        chain.feed(vec![3u8, 5, 10]).feed(vec![5, 12]);
+        let v = chain.generate_with_seed(3);
+        assert!(v == vec![3, 5, 10]);
+        let v = chain.generate_with_seed(1);
+        assert!(v == vec![5, 10]);
+    }
+
+    #[test]
+    fn generate_with_rng() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(3);
+        let mut chain = Chain::new();
+        chain.feed(vec![3u8, 5, 10]).feed(vec![5, 12]);
+        let v = chain.generate_with_rng(&mut rng);
+        assert!(v == vec![3, 5, 10]);
+        let v = chain.generate_with_rng(&mut rng);
+        assert!(v == vec![3, 5, 12]);
+    }
+
+    #[test]
     fn generate_for_higher_order() {
         let mut chain = Chain::of_order(2);
         chain.feed(vec![3u8, 5, 10]).feed(vec![2, 3, 5, 12]);
@@ -542,6 +565,27 @@ mod test {
         chain.feed(vec![3u8, 5, 10]).feed(vec![5, 12]);
         let v = chain.generate_from_token(5);
         assert!([vec![5, 10], vec![5, 12]].contains(&v));
+    }
+
+    #[test]
+    fn generate_from_token_with_seed() {
+        let mut chain = Chain::new();
+        chain.feed(vec![3u8, 5, 10, 13]).feed(vec![5, 12, 10]);
+        let v = chain.generate_from_token_with_seed(5, 3);
+        assert!(v == vec![5, 10, 13]);
+        let v = chain.generate_from_token_with_seed(5, 1);
+        assert!(v == vec![5, 12, 10, 13]);
+    }
+
+    #[test]
+    fn generate_from_token_with_rng() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(3);
+        let mut chain = Chain::new();
+        chain.feed(vec![3u8, 5, 10, 13]).feed(vec![5, 12, 10]);
+        let v = chain.generate_from_token_with_rng(5, &mut rng);
+        assert!(v == vec![5, 10, 13]);
+        let v = chain.generate_from_token_with_rng(5, &mut rng);
+        assert!(v == vec![5, 10]);
     }
 
     #[test]


### PR DESCRIPTION
For a project I need to be able to reproduce the same generation multiple times so I've implemented a way to seed the random number generator, or provide your own generator.

If there is interest in merging such functionality.

---

Add `rand::Rng` argument to `States` trait `next()` function.

Rename `generate` to `generate_base` which now takes an argument that implements `rand::Rng`
Rename `generate_from_token` to `generate_from_token_base` which now takes an argument that implements `rand::Rng`

Add new `generate` and `generate_from_token` functions that call the base functions with `thread_rng()`.

Add the following seedable generate functions
- `generate_with_seed(seed: u64)`
- `generate_with_rng<R: rand::Rng>(rng: R)`
- `generate_from_token_with_seed(token: T, seed: u64)`
- `generate_from_token_with_rng<R: rand::Rng>(token: T, rng: R)`

Implement [linked-hash-map](https://github.com/contain-rs/linked-hash-map) for predictable hashmap insertion.

Add "seedable" feature